### PR TITLE
Document query config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
 # queries
+
 Hosts reusable log queries which are built into a single queries.json file.
+
+## Query database structure
+
+```yaml
+queries:
+  pip-no-matching-distribution:  # also known as query "id", (sort key)
+    pattern: "ERROR: No matching distribution found for"  # required, can be list!
+    # optionals:
+    name: "PIP failed to find package"  # optional (aka 'reason'), id is used instead
+    files: []  # list of glob patterns, narrows down searching
+    regex: false  # optional, default is false
+    url: ... # str or list[str], issue links to lp, bz,...
+    category: ... # see Categories
+    tags: []  # see Tags
+    suppress-graph: false  # used for elastic-recheck
+    # uncommon fields
+    multiline: true  # https://opendev.org/openstack/ansible-role-collect-logs/src/branch/master/vars/sova-patterns.yml#L47
+  another-query-name: ...
+```
+
+Both [elastic-search](https://www.elastic.co/guide/en/elasticsearch/reference/current/term-level-queries.html) and [artcl](https://opendev.org/openstack/ansible-role-collect-logs) can make use of `regex` searches.
+
+Pattern is supposed to be an exact string match and if multiple are present
+we could easily convert them into a regex or logstash expression that uses
+logical `AND`.
+
+### Pattern
+
+On elastic-rechheck queries we have cases with multiple entries used on
+patterns, like `message:foo AND message:bar`. This is why we also allow
+a list of strings.
+
+### Categories
+
+A query can have only one category out of a determined list of possible
+values, currently `infra` and `code` are allowed. These can be used to
+list found matches in section, making them easier to read.
+
+### Tags
+
+Tags are also used to build the logstash queries. List of known values
+already used inside elastic-recheck queries:
+
+```yaml
+tags:
+  - console
+  - console.html
+  - devstack-gate-setup-host.txt
+  - grenade.sh.txt
+  - job-output.txt
+  - screen-c-api.txt
+  - screen-c-bak.txt
+  - screen-n-cpu.txt
+  - screen-n-sch.txt
+  - screen-q-agt.txt
+  - syslog.txt
+```
+
+When logstash query is build `OR` is used between multiple tags.
+
+### Uncovered cases:
+
+We do not currently support the exclusions like below (2/93 found):
+```yaml
+query: >-
+  message:"RESULT_TIMED_OUT: [untrusted : git.openstack.org/openstack/tempest/playbooks/devstack-tempest.yaml@master]" AND
+  tags:"console" AND NOT
+  (build_name:"tempest-all" OR
+   build_name:"tempest-slow" OR
+   build_name:"tempest-slow-py3")
+
+query2: >-
+  (message: "FAILED with status: 137" OR
+  message: "FAILED with status: 143" OR
+  message: "RUN END RESULT_TIMED_OUT") AND
+  NOT message:"POST-RUN END RESULT_TIMED_OUT" AND
+  tags: "console"
+```
+
+To allow us to cover for corner cases not covered byt the generic format,
+we could have an optional `logstash` key that mentions the query. When this
+would be present, we woudl avoid building the logstash query ourselves and
+just use it.
+
+## Disable queries per backend
+
+To avoid using a particular query on a particular backend we can make use of
+``skip: ['er', 'artcl']``.

--- a/src/data/queries.yml
+++ b/src/data/queries.yml
@@ -1,0 +1,19 @@
+# Keep all keys sorted (enforced via CI)
+queries:
+  java_io_exception_remote_call:
+    pattern:
+      - java.io.IOException
+      - Remote call on
+      - failed
+    suppress-graph: true
+    tags:
+      - console.html
+      - job-output.txt
+    url: https://bugs.launchpad.net/openstack-ci/+bug/1260654
+  overcloud_create_failed:
+    name: "Overcloud stack: FAILED."
+    pattern: "Stack overcloud CREATE_FAILED"
+  # from https://opendev.org/opendev/elastic-recheck/src/branch/master/queries/1260654.yaml
+  timeout_re:
+    pattern: Killed\s+timeout -s 9
+    regex: true


### PR DESCRIPTION
Propose generic format to be used to store the queries, one that consolidates features supported by the two tools performing them:

* [elastic-recheck queries](https://opendev.org/opendev/elastic-recheck/src/branch/master/queries)
* [artcl/sova queries](https://opendev.org/openstack/ansible-role-collect-logs/src/branch/master/vars/sova-patterns.yml)


That is more of an initial proposal and it does not aim to necessarily be the final format as we will likely tune it later based on needs.

Main goals is:
- single source of information
- allow use to link bugs from multiple systems, even for the same match (launchpage, bugzilla)
- allow us to reuse queries even if the backend system is changed (avoid hardcoded elastic-search format)
- enforce entry ordering to avoid duplicate and ease natural sorting of queries.

Known issues:
* We were not able to identify the exact difference of first key under sova `patterns:` (console, errors, ironic-conductor, syslog, logstash, bmc, selinux, registry_log) and the **tag** values: infra, code, info.